### PR TITLE
feat(ai): add Prompt and Skill management APIs to align with Java SDK

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import asyncio
+
 from a2a.types import AgentCard, AgentCapabilities, AgentSkill
 from v2.nacos import ClientConfigBuilder
 from v2.nacos.ai.model.mcp.mcp import (
@@ -9,36 +11,18 @@ from v2.nacos.ai.model.mcp.mcp import (
 )
 from v2.nacos.ai.model.mcp.registry import ServerVersionDetail
 
+from maintainer.ai.model.skill import Skill, SkillResource
 from maintainer.ai.nacos_ai_maintainer_service import NacosAIMaintainerService
 
 
-async def main():
-    ai_client_config = (
-        ClientConfigBuilder()
-        .server_address(
-            "localhost:8848",
-        )
-        .username(
-            "nacos",
-        )
-        .password(
-            "nacos",
-        )
-        .build()
-    )
-    mcp_service = await NacosAIMaintainerService.create_ai_service(
-        ai_client_config,
-    )
+async def mcp_example(service: NacosAIMaintainerService):
+    """MCP Server management example."""
+    print("=== MCP Server Example ===")
+
     tool_spec = [
-        McpTool(
-            name="test_tool",
-            description="test tool",
-            inputSchema={},
-        ),
+        McpTool(name="test_tool", description="test tool", inputSchema={}),
     ]
-    mcp_tool_specification = McpToolSpecification(
-        tools=tool_spec,
-    )
+    mcp_tool_specification = McpToolSpecification(tools=tool_spec)
 
     server_version_detail = ServerVersionDetail()
     server_version_detail.version = "0.1.0"
@@ -46,47 +30,38 @@ async def main():
     server_basic_info.name = "nacos-mcp-server"
     server_basic_info.versionDetail = server_version_detail
     server_basic_info.description = "test mcp server"
-
     server_basic_info.protocol = "stdio"
     server_basic_info.frontProtocol = "stdio"
 
-    await mcp_service.create_mcp_server(
-        "public",
-        "nacos-mcp-server",
-        server_basic_info,
-        mcp_tool_specification,
-        McpEndpointSpec(),
+    await service.create_mcp_server(
+        "public", "nacos-mcp-server",
+        server_basic_info, mcp_tool_specification, McpEndpointSpec(),
     )
     await asyncio.sleep(3)
-    print(
-        await mcp_service.get_mcp_server_detail(
-            "public",
-            "nacos-mcp-server",
-            "0.1.0",
-        ),
-    )
+    print(await service.get_mcp_server_detail(
+        "public", "nacos-mcp-server", "0.1.0",
+    ))
+    print(await service.search_mcp_server(
+        "public", "nacos-mcp-server", 1, 10,
+    ))
+    print(await service.list_mcp_servers("public", "", 1, 10))
 
-    print(
-        await mcp_service.search_mcp_server(
-            "public", "nacos-mcp-server", 1, 10
-        )
-    )
-    print(await mcp_service.list_mcp_servers("public", "", 1, 10))
     server_version_detail.version = "0.2.0"
-    await mcp_service.update_mcp_server(
-        "public",
-        "nacos-mcp-server",
-        True,
-        server_basic_info,
-        mcp_tool_specification,
-        McpEndpointSpec(),
+    await service.update_mcp_server(
+        "public", "nacos-mcp-server", True,
+        server_basic_info, mcp_tool_specification, McpEndpointSpec(),
     )
     await asyncio.sleep(3)
-    await mcp_service.delete_mcp_server("public", "nacos-mcp-server")
+    await service.delete_mcp_server("public", "nacos-mcp-server")
+    print("=== MCP Server Example Done ===\n")
+
+
+async def a2a_example(service: NacosAIMaintainerService):
+    """A2A Agent management example."""
+    print("=== A2A Agent Example ===")
 
     capabilities = AgentCapabilities(
-        streaming=False,
-        push_notifications=False,
+        streaming=False, push_notifications=False,
     )
     skill = AgentSkill(
         id="dialog",
@@ -94,12 +69,8 @@ async def main():
         description="Enables natural language conversation and dialogue "
         "with users",
         tags=["natural language", "dialog", "conversation"],
-        examples=[
-            "Hello, how are you?",
-            "Can you help me with something?",
-        ],
+        examples=["Hello, how are you?", "Can you help me with something?"],
     )
-
     agent_card = AgentCard(
         capabilities=capabilities,
         skills=[skill],
@@ -111,51 +82,162 @@ async def main():
         version="1.0.0",
     )
 
-    await mcp_service.register_agent(
-        agent_card=agent_card, namespace_id="public", registration_type="URL"
-    )
-    print(
-        await mcp_service.get_agent_card(
-            namespace_id="public",
-            agent_name="nacos_a2a_agent",
-            registration_type="URL",
-        )
-    )
-    agent_card.version = "1.0.1"
-    await mcp_service.update_agent_card(
-        agent_card=agent_card,
-        namespace_id="public",
-        set_as_latest=True,
+    await service.register_agent(
+        agent_card=agent_card, namespace_id="public",
         registration_type="URL",
     )
-    print(
-        await mcp_service.list_all_version_of_agent(
-            namespace_id="public", agent_name="nacos_a2a_agent"
-        )
+    print(await service.get_agent_card(
+        namespace_id="public", agent_name="nacos_a2a_agent",
+        registration_type="URL",
+    ))
+    agent_card.version = "1.0.1"
+    await service.update_agent_card(
+        agent_card=agent_card, namespace_id="public",
+        set_as_latest=True, registration_type="URL",
     )
-    print(
-        await mcp_service.list_agent_cards_by_name(
-            namespace_id="public",
-            agent_name="nacos_a2a_agent",
-            page_no=1,
-            page_size=10,
-        )
+    print(await service.list_all_version_of_agent(
+        namespace_id="public", agent_name="nacos_a2a_agent",
+    ))
+    print(await service.list_agent_cards_by_name(
+        namespace_id="public", agent_name="nacos_a2a_agent",
+        page_no=1, page_size=10,
+    ))
+    print(await service.search_agent_cards_by_name(
+        namespace_id="public", agent_name_pattern="nacos_a2a_agent",
+        page_no=1, page_size=10,
+    ))
+    await service.delete_agent(
+        namespace_id="public", agent_name="nacos_a2a_agent",
     )
-    print(
-        await mcp_service.search_agent_cards_by_name(
-            namespace_id="public",
-            agent_name_pattern="nacos_a2a_agent",
-            page_no=1,
-            page_size=10,
-        )
+    print("=== A2A Agent Example Done ===\n")
+
+
+async def prompt_example(service: NacosAIMaintainerService):
+    """Prompt management example."""
+    print("=== Prompt Example ===")
+
+    print("[1] Publishing prompt v1.0.0...")
+    result = await service.publish_prompt(
+        namespace_id="public",
+        prompt_key="example-prompt",
+        version="1.0.0",
+        template="Hello {{name}}, you are a {{role}}.",
+        commit_msg="initial version",
+        description="Example prompt template",
     )
-    await asyncio.sleep(100)
-    await mcp_service.delete_agent(
-        namespace_id="public", agent_name="nacos_a2a_agent"
+    print(f"    publish result: {result}")
+
+    print("[2] Getting prompt metadata...")
+    meta = await service.get_prompt_meta("public", "example-prompt")
+    print(f"    meta: {meta}")
+
+    print("[3] Querying prompt detail...")
+    detail = await service.query_prompt_detail(
+        "public", "example-prompt", version="1.0.0",
     )
+    print(f"    detail: {detail}")
+
+    print("[4] Publishing prompt v2.0.0...")
+    await service.publish_prompt(
+        namespace_id="public",
+        prompt_key="example-prompt",
+        version="2.0.0",
+        template="Hi {{name}}, welcome to {{department}}!",
+        commit_msg="add department variable",
+    )
+
+    print("[5] Listing prompt versions...")
+    total, page_num, pages, versions = await service.list_prompt_versions(
+        "public", "example-prompt", 1, 10,
+    )
+    print(f"    total: {total}, versions: {versions}")
+
+    print("[6] Binding label 'prod' to v1.0.0...")
+    await service.bind_label("public", "example-prompt", "prod", "1.0.0")
+
+    print("[7] Querying prompt by label 'prod'...")
+    detail_by_label = await service.query_prompt_detail(
+        "public", "example-prompt", label="prod",
+    )
+    print(f"    detail: {detail_by_label}")
+
+    print("[8] Updating prompt metadata...")
+    await service.update_prompt_metadata(
+        "public", "example-prompt",
+        description="Updated description",
+        biz_tags="tag1,tag2",
+    )
+
+    print("[9] Listing all prompts...")
+    total, page_num, pages, prompts = await service.search_prompts(
+        "public", "example", 1, 10,
+    )
+    print(f"    total: {total}, prompts: {prompts}")
+
+    print("[10] Unbinding label...")
+    await service.unbind_label("public", "example-prompt", "prod")
+
+    print("[11] Deleting prompt...")
+    await service.delete_prompt("public", "example-prompt")
+    print("=== Prompt Example Done ===\n")
+
+
+async def skill_example(service: NacosAIMaintainerService):
+    """Skill management example."""
+    print("=== Skill Example ===")
+
+    print("[1] Registering skill...")
+    skill = Skill(
+        name="example-skill",
+        description="An example skill for testing",
+        instruction="Follow the instructions to complete the task.",
+        resource={
+            "main": SkillResource(
+                name="main-resource",
+                type="text",
+                content="This is the main resource content.",
+            ),
+        },
+    )
+    result = await service.register_skill("public", skill)
+    print(f"    register result: {result}")
+
+    print("[2] Getting skill detail...")
+    detail = await service.get_skill_detail("public", "example-skill")
+    print(f"    detail: {detail}")
+
+    print("[3] Updating skill...")
+    skill.description = "Updated skill description"
+    await service.update_skill("public", skill)
+
+    print("[4] Listing skills...")
+    total, page_num, pages, skills = await service.search_skills(
+        "public", "example", 1, 10,
+    )
+    print(f"    total: {total}, skills: {skills}")
+
+    print("[5] Deleting skill...")
+    await service.delete_skill("public", "example-skill")
+    print("=== Skill Example Done ===\n")
+
+
+async def main():
+    ai_client_config = (
+        ClientConfigBuilder()
+        .server_address("localhost:8848")
+        .username("nacos")
+        .password("nacos")
+        .build()
+    )
+    service = await NacosAIMaintainerService.create_ai_service(
+        ai_client_config,
+    )
+
+    await prompt_example(service)
+    await skill_example(service)
+    await mcp_example(service)
+    await a2a_example(service)
 
 
 if __name__ == "__main__":
-    import asyncio
-
     print(asyncio.run(main()))

--- a/maintainer/ai/model/prompt.py
+++ b/maintainer/ai/model/prompt.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from typing import Optional, List, Dict
+
+from pydantic import BaseModel, Field
+
+
+class PromptMetaSummary(BaseModel):
+    schema_version: Optional[int] = Field(default=1, alias="schemaVersion")
+    prompt_key: Optional[str] = Field(default=None, alias="promptKey")
+    description: Optional[str] = None
+    biz_tags: Optional[List[str]] = Field(default=None, alias="bizTags")
+    latest_version: Optional[str] = Field(default=None, alias="latestVersion")
+    gmt_modified: Optional[int] = Field(default=None, alias="gmtModified")
+
+    model_config = {"populate_by_name": True}
+
+
+class PromptMetaInfo(PromptMetaSummary):
+    versions: Optional[List[str]] = None
+    labels: Optional[Dict[str, str]] = None
+
+
+class PromptVersionSummary(BaseModel):
+    prompt_key: Optional[str] = Field(default=None, alias="promptKey")
+    version: Optional[str] = None
+    commit_msg: Optional[str] = Field(default=None, alias="commitMsg")
+    src_user: Optional[str] = Field(default=None, alias="srcUser")
+    gmt_modified: Optional[int] = Field(default=None, alias="gmtModified")
+
+    model_config = {"populate_by_name": True}
+
+
+class PromptVersionInfo(PromptVersionSummary):
+    template: Optional[str] = None
+    md5: Optional[str] = None

--- a/maintainer/ai/model/skill.py
+++ b/maintainer/ai/model/skill.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from typing import Optional, Dict, Any
+
+from pydantic import BaseModel, Field
+
+
+class SkillResource(BaseModel):
+    name: Optional[str] = None
+    type: Optional[str] = None
+    content: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class Skill(BaseModel):
+    namespace_id: Optional[str] = Field(default=None, alias="namespaceId")
+    name: Optional[str] = None
+    description: Optional[str] = None
+    instruction: Optional[str] = None
+    resource: Optional[Dict[str, SkillResource]] = None
+
+    model_config = {"populate_by_name": True}
+
+
+class SkillBasicInfo(BaseModel):
+    namespace_id: Optional[str] = Field(default=None, alias="namespaceId")
+    name: Optional[str] = None
+    description: Optional[str] = None
+    update_time: Optional[int] = Field(default=None, alias="updateTime")
+
+    model_config = {"populate_by_name": True}

--- a/maintainer/ai/nacos_ai_maintainer_service.py
+++ b/maintainer/ai/nacos_ai_maintainer_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 from a2a.types import AgentCard
 from pydantic import TypeAdapter
@@ -14,6 +14,13 @@ from v2.nacos.ai.model.mcp.mcp import (
 from v2.nacos.common.constants import Constants
 
 from maintainer.ai.model.a2a import AgentVersionDetail, AgentCardVersionInfo
+from maintainer.ai.model.prompt import (
+    PromptMetaSummary,
+    PromptMetaInfo,
+    PromptVersionSummary,
+    PromptVersionInfo,
+)
+from maintainer.ai.model.skill import Skill, SkillBasicInfo
 from maintainer.common.auth import RequestResource
 from maintainer.nacos_maintainer_client import NacosMaintainerClient
 from maintainer.transport.client_http_proxy import ClientHttpProxy, HttpRequest
@@ -593,3 +600,549 @@ class NacosAIMaintainerService(NacosMaintainerClient):
             page_available,
             agent_card_version_info_list,
         )
+
+    # ========== Prompt Maintainer Service ==========
+
+    async def list_prompts(
+        self,
+        namespace_id: str,
+        prompt_key: str,
+        search: str,
+        biz_tags: Optional[str],
+        page_no: int,
+        page_size: int,
+    ) -> Tuple[int, int, int, List[PromptMetaSummary]]:
+        if namespace_id is None or len(namespace_id) == 0:
+            namespace_id = DEFAULT_NAMESPACE_ID
+
+        params = {
+            "namespaceId": namespace_id,
+            "promptKey": prompt_key,
+            "search": search,
+            "pageNo": page_no,
+            "pageSize": page_size,
+        }
+        if biz_tags is not None and len(biz_tags) > 0:
+            params["bizTags"] = biz_tags
+
+        request_resource = RequestResource(
+            Constants.AI_MODULE, namespace_id, "", prompt_key,
+        )
+        request = HttpRequest(
+            path="/nacos/v3/admin/ai/prompt/list",
+            method="GET",
+            request_resource=request_resource,
+            params=params,
+        )
+        result = await self.http_proxy.request(request)
+        if result["code"] != 0:
+            self.logger.error(f"list prompts failed, result:{result}")
+            raise Exception(result["message"])
+
+        result_data = result["data"]
+        total_count = result_data["totalCount"]
+        page_number = result_data["pageNumber"]
+        page_available = result_data["pagesAvailable"]
+        page_items = result_data["pageItems"]
+        adapter = TypeAdapter(List[PromptMetaSummary])
+        prompts = adapter.validate_python(page_items)
+        return total_count, page_number, page_available, prompts
+
+    async def search_prompts(
+        self,
+        namespace_id: str,
+        prompt_key: str,
+        page_no: int,
+        page_size: int,
+        biz_tags: Optional[str] = None,
+    ) -> Tuple[int, int, int, List[PromptMetaSummary]]:
+        return await self.list_prompts(
+            namespace_id, prompt_key, "blur", biz_tags, page_no, page_size,
+        )
+
+    async def get_prompt_meta(
+        self,
+        namespace_id: str,
+        prompt_key: str,
+    ) -> PromptMetaInfo:
+        if namespace_id is None or len(namespace_id) == 0:
+            namespace_id = DEFAULT_NAMESPACE_ID
+
+        params = {
+            "namespaceId": namespace_id,
+            "promptKey": prompt_key,
+        }
+        request_resource = RequestResource(
+            Constants.AI_MODULE, namespace_id, "", prompt_key,
+        )
+        request = HttpRequest(
+            path="/nacos/v3/admin/ai/prompt/metadata",
+            method="GET",
+            request_resource=request_resource,
+            params=params,
+        )
+        result = await self.http_proxy.request(request)
+        if result["code"] != 0:
+            self.logger.error(f"get prompt meta failed, result:{result}")
+            raise Exception(result["message"])
+
+        adapter = TypeAdapter(PromptMetaInfo)
+        return adapter.validate_python(result["data"])
+
+    async def query_prompt_detail(
+        self,
+        namespace_id: str,
+        prompt_key: str,
+        version: Optional[str] = None,
+        label: Optional[str] = None,
+    ) -> PromptVersionInfo:
+        if namespace_id is None or len(namespace_id) == 0:
+            namespace_id = DEFAULT_NAMESPACE_ID
+
+        params = {
+            "namespaceId": namespace_id,
+            "promptKey": prompt_key,
+        }
+        if version is not None and len(version) > 0:
+            params["version"] = version
+        if label is not None and len(label) > 0:
+            params["label"] = label
+
+        request_resource = RequestResource(
+            Constants.AI_MODULE, namespace_id, "", prompt_key,
+        )
+        request = HttpRequest(
+            path="/nacos/v3/admin/ai/prompt/detail",
+            method="GET",
+            request_resource=request_resource,
+            params=params,
+        )
+        result = await self.http_proxy.request(request)
+        if result["code"] != 0:
+            self.logger.error(
+                f"query prompt detail failed, result:{result}",
+            )
+            raise Exception(result["message"])
+
+        adapter = TypeAdapter(PromptVersionInfo)
+        return adapter.validate_python(result["data"])
+
+    async def publish_prompt(
+        self,
+        namespace_id: str,
+        prompt_key: str,
+        version: str,
+        template: str,
+        commit_msg: Optional[str] = None,
+        description: Optional[str] = None,
+        biz_tags: Optional[str] = None,
+    ) -> bool:
+        if namespace_id is None or len(namespace_id) == 0:
+            namespace_id = DEFAULT_NAMESPACE_ID
+
+        params = {
+            "namespaceId": namespace_id,
+            "promptKey": prompt_key,
+            "version": version,
+            "template": template,
+        }
+        if commit_msg is not None and len(commit_msg) > 0:
+            params["commitMsg"] = commit_msg
+        if description is not None and len(description) > 0:
+            params["description"] = description
+        if biz_tags is not None and len(biz_tags) > 0:
+            params["bizTags"] = biz_tags
+
+        request_resource = RequestResource(
+            Constants.AI_MODULE, namespace_id, "", prompt_key,
+        )
+        request = HttpRequest(
+            path="/nacos/v3/admin/ai/prompt",
+            method="POST",
+            request_resource=request_resource,
+            data=params,
+        )
+        result = await self.http_proxy.request(request)
+        if result["code"] != 0:
+            self.logger.error(f"publish prompt failed, result:{result}")
+            return False
+
+        return True
+
+    async def delete_prompt(
+        self,
+        namespace_id: str,
+        prompt_key: str,
+    ) -> bool:
+        if namespace_id is None or len(namespace_id) == 0:
+            namespace_id = DEFAULT_NAMESPACE_ID
+
+        params = {
+            "namespaceId": namespace_id,
+            "promptKey": prompt_key,
+        }
+        request_resource = RequestResource(
+            Constants.AI_MODULE, namespace_id, "", prompt_key,
+        )
+        request = HttpRequest(
+            path="/nacos/v3/admin/ai/prompt",
+            method="DELETE",
+            request_resource=request_resource,
+            params=params,
+        )
+        result = await self.http_proxy.request(request)
+        if result["code"] != 0:
+            self.logger.error(f"delete prompt failed, result:{result}")
+            return False
+
+        return True
+
+    async def list_prompt_versions(
+        self,
+        namespace_id: str,
+        prompt_key: str,
+        page_no: int,
+        page_size: int,
+    ) -> Tuple[int, int, int, List[PromptVersionSummary]]:
+        if namespace_id is None or len(namespace_id) == 0:
+            namespace_id = DEFAULT_NAMESPACE_ID
+
+        params = {
+            "namespaceId": namespace_id,
+            "promptKey": prompt_key,
+            "pageNo": page_no,
+            "pageSize": page_size,
+        }
+        request_resource = RequestResource(
+            Constants.AI_MODULE, namespace_id, "", prompt_key,
+        )
+        request = HttpRequest(
+            path="/nacos/v3/admin/ai/prompt/versions",
+            method="GET",
+            request_resource=request_resource,
+            params=params,
+        )
+        result = await self.http_proxy.request(request)
+        if result["code"] != 0:
+            self.logger.error(
+                f"list prompt versions failed, result:{result}",
+            )
+            raise Exception(result["message"])
+
+        result_data = result["data"]
+        total_count = result_data["totalCount"]
+        page_number = result_data["pageNumber"]
+        page_available = result_data["pagesAvailable"]
+        page_items = result_data["pageItems"]
+        adapter = TypeAdapter(List[PromptVersionSummary])
+        versions = adapter.validate_python(page_items)
+        return total_count, page_number, page_available, versions
+
+    async def update_prompt_metadata(
+        self,
+        namespace_id: str,
+        prompt_key: str,
+        description: Optional[str] = None,
+        biz_tags: Optional[str] = None,
+    ) -> bool:
+        if namespace_id is None or len(namespace_id) == 0:
+            namespace_id = DEFAULT_NAMESPACE_ID
+
+        params = {
+            "namespaceId": namespace_id,
+            "promptKey": prompt_key,
+        }
+        if description is not None:
+            params["description"] = description
+        if biz_tags is not None:
+            params["bizTags"] = biz_tags
+
+        request_resource = RequestResource(
+            Constants.AI_MODULE, namespace_id, "", prompt_key,
+        )
+        request = HttpRequest(
+            path="/nacos/v3/admin/ai/prompt/metadata",
+            method="PUT",
+            request_resource=request_resource,
+            data=params,
+        )
+        result = await self.http_proxy.request(request)
+        if result["code"] != 0:
+            self.logger.error(
+                f"update prompt metadata failed, result:{result}",
+            )
+            return False
+
+        return True
+
+    async def bind_label(
+        self,
+        namespace_id: str,
+        prompt_key: str,
+        label: str,
+        version: str,
+    ) -> bool:
+        if namespace_id is None or len(namespace_id) == 0:
+            namespace_id = DEFAULT_NAMESPACE_ID
+
+        params = {
+            "namespaceId": namespace_id,
+            "promptKey": prompt_key,
+            "label": label,
+            "version": version,
+        }
+        request_resource = RequestResource(
+            Constants.AI_MODULE, namespace_id, "", prompt_key,
+        )
+        request = HttpRequest(
+            path="/nacos/v3/admin/ai/prompt/label",
+            method="PUT",
+            request_resource=request_resource,
+            data=params,
+        )
+        result = await self.http_proxy.request(request)
+        if result["code"] != 0:
+            self.logger.error(f"bind label failed, result:{result}")
+            return False
+
+        return True
+
+    async def unbind_label(
+        self,
+        namespace_id: str,
+        prompt_key: str,
+        label: str,
+    ) -> bool:
+        if namespace_id is None or len(namespace_id) == 0:
+            namespace_id = DEFAULT_NAMESPACE_ID
+
+        params = {
+            "namespaceId": namespace_id,
+            "promptKey": prompt_key,
+            "label": label,
+        }
+        request_resource = RequestResource(
+            Constants.AI_MODULE, namespace_id, "", prompt_key,
+        )
+        request = HttpRequest(
+            path="/nacos/v3/admin/ai/prompt/label",
+            method="DELETE",
+            request_resource=request_resource,
+            params=params,
+        )
+        result = await self.http_proxy.request(request)
+        if result["code"] != 0:
+            self.logger.error(f"unbind label failed, result:{result}")
+            return False
+
+        return True
+
+    # ========== Skill Maintainer Service ==========
+
+    async def register_skill(
+        self,
+        namespace_id: str,
+        skill: Skill,
+    ) -> str:
+        if namespace_id is None or len(namespace_id) == 0:
+            namespace_id = DEFAULT_NAMESPACE_ID
+
+        params = {
+            "namespaceId": namespace_id,
+            "skillCard": skill.model_dump_json(
+                exclude_none=True, by_alias=True,
+            ),
+        }
+        request_resource = RequestResource(
+            Constants.AI_MODULE, namespace_id, "", skill.name,
+        )
+        request = HttpRequest(
+            path="/nacos/v3/admin/ai/skills",
+            method="POST",
+            request_resource=request_resource,
+            data=params,
+        )
+        result = await self.http_proxy.request(request)
+        if result["code"] != 0:
+            self.logger.error(f"register skill failed, result:{result}")
+            raise Exception(result["message"])
+
+        return result["data"]
+
+    async def get_skill_detail(
+        self,
+        namespace_id: str,
+        skill_name: str,
+    ) -> Skill:
+        if namespace_id is None or len(namespace_id) == 0:
+            namespace_id = DEFAULT_NAMESPACE_ID
+
+        params = {
+            "namespaceId": namespace_id,
+            "skillName": skill_name,
+        }
+        request_resource = RequestResource(
+            Constants.AI_MODULE, namespace_id, "", skill_name,
+        )
+        request = HttpRequest(
+            path="/nacos/v3/admin/ai/skills",
+            method="GET",
+            request_resource=request_resource,
+            params=params,
+        )
+        result = await self.http_proxy.request(request)
+        if result["code"] != 0:
+            self.logger.error(
+                f"get skill detail failed, result:{result}",
+            )
+            raise Exception(result["message"])
+
+        adapter = TypeAdapter(Skill)
+        return adapter.validate_python(result["data"])
+
+    async def update_skill(
+        self,
+        namespace_id: str,
+        skill: Skill,
+    ) -> bool:
+        if namespace_id is None or len(namespace_id) == 0:
+            namespace_id = DEFAULT_NAMESPACE_ID
+
+        params = {
+            "namespaceId": namespace_id,
+            "skillCard": skill.model_dump_json(
+                exclude_none=True, by_alias=True,
+            ),
+        }
+        request_resource = RequestResource(
+            Constants.AI_MODULE, namespace_id, "", skill.name,
+        )
+        request = HttpRequest(
+            path="/nacos/v3/admin/ai/skills",
+            method="PUT",
+            request_resource=request_resource,
+            data=params,
+        )
+        result = await self.http_proxy.request(request)
+        if result["code"] != 0:
+            self.logger.error(f"update skill failed, result:{result}")
+            return False
+
+        return True
+
+    async def delete_skill(
+        self,
+        namespace_id: str,
+        skill_name: str,
+    ) -> bool:
+        if namespace_id is None or len(namespace_id) == 0:
+            namespace_id = DEFAULT_NAMESPACE_ID
+
+        params = {
+            "namespaceId": namespace_id,
+            "skillName": skill_name,
+        }
+        request_resource = RequestResource(
+            Constants.AI_MODULE, namespace_id, "", skill_name,
+        )
+        request = HttpRequest(
+            path="/nacos/v3/admin/ai/skills",
+            method="DELETE",
+            request_resource=request_resource,
+            params=params,
+        )
+        result = await self.http_proxy.request(request)
+        if result["code"] != 0:
+            self.logger.error(f"delete skill failed, result:{result}")
+            return False
+
+        return True
+
+    async def list_skills(
+        self,
+        namespace_id: str,
+        skill_name: str,
+        search: str,
+        page_no: int,
+        page_size: int,
+    ) -> Tuple[int, int, int, List[SkillBasicInfo]]:
+        if namespace_id is None or len(namespace_id) == 0:
+            namespace_id = DEFAULT_NAMESPACE_ID
+
+        params = {
+            "namespaceId": namespace_id,
+            "skillName": skill_name,
+            "search": search,
+            "pageNo": page_no,
+            "pageSize": page_size,
+        }
+        request_resource = RequestResource(
+            Constants.AI_MODULE, namespace_id, "", skill_name,
+        )
+        request = HttpRequest(
+            path="/nacos/v3/admin/ai/skills/list",
+            method="GET",
+            request_resource=request_resource,
+            params=params,
+        )
+        result = await self.http_proxy.request(request)
+        if result["code"] != 0:
+            self.logger.error(f"list skills failed, result:{result}")
+            raise Exception(result["message"])
+
+        result_data = result["data"]
+        total_count = result_data["totalCount"]
+        page_number = result_data["pageNumber"]
+        page_available = result_data["pagesAvailable"]
+        page_items = result_data["pageItems"]
+        adapter = TypeAdapter(List[SkillBasicInfo])
+        skills = adapter.validate_python(page_items)
+        return total_count, page_number, page_available, skills
+
+    async def search_skills(
+        self,
+        namespace_id: str,
+        skill_name: str,
+        page_no: int,
+        page_size: int,
+    ) -> Tuple[int, int, int, List[SkillBasicInfo]]:
+        return await self.list_skills(
+            namespace_id, skill_name, "blur", page_no, page_size,
+        )
+
+    async def upload_skill_from_zip(
+        self,
+        namespace_id: str,
+        zip_bytes: bytes,
+    ) -> str:
+        if namespace_id is None or len(namespace_id) == 0:
+            namespace_id = DEFAULT_NAMESPACE_ID
+
+        import aiohttp
+
+        form_data = aiohttp.FormData()
+        form_data.add_field("namespaceId", namespace_id)
+        form_data.add_field(
+            "file",
+            zip_bytes,
+            filename="skill.zip",
+            content_type="application/zip",
+        )
+
+        request_resource = RequestResource(
+            Constants.AI_MODULE, namespace_id, "", None,
+        )
+        request = HttpRequest(
+            path="/nacos/v3/admin/ai/skills/upload",
+            method="POST",
+            request_resource=request_resource,
+        )
+        request.form_data = form_data
+        result = await self.http_proxy.request(request)
+        if result["code"] != 0:
+            self.logger.error(
+                f"upload skill from zip failed, result:{result}",
+            )
+            raise Exception(result["message"])
+
+        return result["data"]

--- a/maintainer/transport/client_http_proxy.py
+++ b/maintainer/transport/client_http_proxy.py
@@ -42,6 +42,7 @@ class HttpRequest:
         if data is None:
             data = {}
         self.data = data
+        self.form_data = None
 
 
 class ClientHttpProxy:
@@ -147,13 +148,26 @@ class ClientHttpProxy:
         while get_current_time_millis() < end_time and retry_count > 0:
             try:
                 url = self.get_next_server() + http_reqeust.path
-                resp, err_code, error_msg = await self.http_agent.request(
-                    url,
-                    http_reqeust.method,
-                    headers,
-                    http_reqeust.params,
-                    http_reqeust.data,
-                )
+                if http_reqeust.form_data is not None:
+                    resp, err_code, error_msg = (
+                        await self.http_agent.request(
+                            url,
+                            http_reqeust.method,
+                            headers,
+                            http_reqeust.params,
+                            http_reqeust.form_data,
+                        )
+                    )
+                else:
+                    resp, err_code, error_msg = (
+                        await self.http_agent.request(
+                            url,
+                            http_reqeust.method,
+                            headers,
+                            http_reqeust.params,
+                            http_reqeust.data,
+                        )
+                    )
                 if not resp or error_msg:
                     self.logger.error(f"request error: {error_msg}")
                     raise NacosException(err_code, error_msg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nacos-maintainer-sdk-python"
-version = "0.5.3"
+version = "0.6.0b1"
 description = "Nacos Maintainer Sdk for Python"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/test_prompt_skill.py
+++ b/test_prompt_skill.py
@@ -1,0 +1,230 @@
+# -*- coding: utf-8 -*-
+import asyncio
+import os
+import traceback
+
+from v2.nacos import ClientConfigBuilder
+
+from maintainer.ai.model.skill import Skill, SkillResource
+from maintainer.ai.nacos_ai_maintainer_service import NacosAIMaintainerService
+
+SERVER = "localhost:8848"
+USERNAME = "nacos"
+PASSWORD = "nacos"
+NAMESPACE = "public"
+
+PROMPT_KEY = "sdk-test-prompt"
+SKILL_NAME = "sdk-test-skill"
+
+ZIP_PATH = os.path.join(os.path.dirname(__file__), "pdf.zip")
+
+
+async def test_prompt(service: NacosAIMaintainerService):
+    print("=" * 60)
+    print("  Prompt API Tests")
+    print("=" * 60)
+
+    # 1. publish prompt v1.0.0
+    print("\n[1] publish_prompt v1.0.0 ...")
+    ok = await service.publish_prompt(
+        namespace_id=NAMESPACE,
+        prompt_key=PROMPT_KEY,
+        version="1.0.0",
+        template="Hello {{name}}, you are a {{role}}.",
+        commit_msg="initial version",
+        description="SDK test prompt",
+        biz_tags="test,sdk",
+    )
+    print(f"    result: {ok}")
+    assert ok, "publish_prompt v1.0.0 failed"
+
+    await asyncio.sleep(1)
+
+    # 2. publish prompt v2.0.0
+    print("\n[2] publish_prompt v2.0.0 ...")
+    ok = await service.publish_prompt(
+        namespace_id=NAMESPACE,
+        prompt_key=PROMPT_KEY,
+        version="2.0.0",
+        template="Hi {{name}}, welcome to {{department}}!",
+        commit_msg="add department",
+    )
+    print(f"    result: {ok}")
+    assert ok, "publish_prompt v2.0.0 failed"
+
+    await asyncio.sleep(1)
+
+    # 3. get_prompt_meta
+    print("\n[3] get_prompt_meta ...")
+    meta = await service.get_prompt_meta(NAMESPACE, PROMPT_KEY)
+    print(f"    promptKey: {meta.prompt_key}")
+    print(f"    description: {meta.description}")
+    print(f"    versions: {meta.versions}")
+    print(f"    labels: {meta.labels}")
+    print(f"    latestVersion: {meta.latest_version}")
+
+    # 4. query_prompt_detail by version
+    print("\n[4] query_prompt_detail (version=1.0.0) ...")
+    detail = await service.query_prompt_detail(
+        NAMESPACE, PROMPT_KEY, version="1.0.0",
+    )
+    print(f"    promptKey: {detail.prompt_key}")
+    print(f"    version: {detail.version}")
+    print(f"    template: {detail.template}")
+    print(f"    md5: {detail.md5}")
+
+    # 5. list_prompt_versions
+    print("\n[5] list_prompt_versions ...")
+    total, page_num, pages, versions = await service.list_prompt_versions(
+        NAMESPACE, PROMPT_KEY, 1, 10,
+    )
+    print(f"    total: {total}")
+    for v in versions:
+        print(f"    - {v.version} ({v.commit_msg})")
+
+    # 6. bind_label
+    print("\n[6] bind_label 'prod' -> v1.0.0 ...")
+    ok = await service.bind_label(NAMESPACE, PROMPT_KEY, "prod", "1.0.0")
+    print(f"    result: {ok}")
+
+    await asyncio.sleep(1)
+
+    # 7. query_prompt_detail by label
+    print("\n[7] query_prompt_detail (label=prod) ...")
+    detail_label = await service.query_prompt_detail(
+        NAMESPACE, PROMPT_KEY, label="prod",
+    )
+    print(f"    version: {detail_label.version}")
+    print(f"    template: {detail_label.template}")
+
+    # 8. update_prompt_metadata
+    print("\n[8] update_prompt_metadata ...")
+    ok = await service.update_prompt_metadata(
+        NAMESPACE, PROMPT_KEY,
+        description="Updated SDK test prompt",
+        biz_tags="test,sdk,updated",
+    )
+    print(f"    result: {ok}")
+
+    await asyncio.sleep(1)
+
+    # 9. list_prompts (search)
+    print("\n[9] search_prompts ...")
+    total, page_num, pages, prompts = await service.search_prompts(
+        NAMESPACE, "sdk-test", 1, 10,
+    )
+    print(f"    total: {total}")
+    for p in prompts:
+        print(f"    - {p.prompt_key} (latest={p.latest_version})")
+
+    # 10. unbind_label
+    print("\n[10] unbind_label 'prod' ...")
+    ok = await service.unbind_label(NAMESPACE, PROMPT_KEY, "prod")
+    print(f"    result: {ok}")
+
+    # 11. delete_prompt
+    print("\n[11] delete_prompt ...")
+    ok = await service.delete_prompt(NAMESPACE, PROMPT_KEY)
+    print(f"    result: {ok}")
+
+    print("\n  Prompt API Tests: ALL PASSED")
+
+
+async def test_skill(service: NacosAIMaintainerService):
+    print("\n" + "=" * 60)
+    print("  Skill API Tests")
+    print("=" * 60)
+
+    # 1. register_skill
+    print("\n[1] register_skill ...")
+    skill = Skill(
+        name=SKILL_NAME,
+        description="SDK test skill",
+        instruction="Follow the instructions.",
+        resource={
+            "main": SkillResource(
+                name="main-res",
+                type="text",
+                content="This is test content.",
+            ),
+        },
+    )
+    result = await service.register_skill(NAMESPACE, skill)
+    print(f"    result: {result}")
+
+    await asyncio.sleep(1)
+
+    # 2. get_skill_detail
+    print("\n[2] get_skill_detail ...")
+    detail = await service.get_skill_detail(NAMESPACE, SKILL_NAME)
+    print(f"    name: {detail.name}")
+    print(f"    description: {detail.description}")
+    print(f"    instruction: {detail.instruction}")
+
+    # 3. update_skill
+    print("\n[3] update_skill ...")
+    skill.description = "Updated SDK test skill"
+    ok = await service.update_skill(NAMESPACE, skill)
+    print(f"    result: {ok}")
+
+    await asyncio.sleep(1)
+
+    # 4. list_skills (search)
+    print("\n[4] search_skills ...")
+    total, page_num, pages, skills = await service.search_skills(
+        NAMESPACE, "sdk-test", 1, 10,
+    )
+    print(f"    total: {total}")
+    for s in skills:
+        print(f"    - {s.name} ({s.description})")
+
+    # 5. delete_skill
+    print("\n[5] delete_skill ...")
+    ok = await service.delete_skill(NAMESPACE, SKILL_NAME)
+    print(f"    result: {ok}")
+
+    await asyncio.sleep(1)
+
+    # 6. upload_skill_from_zip
+    print(f"\n[6] upload_skill_from_zip ({ZIP_PATH}) ...")
+    if os.path.exists(ZIP_PATH):
+        with open(ZIP_PATH, "rb") as f:
+            zip_bytes = f.read()
+        print(f"    zip size: {len(zip_bytes)} bytes")
+        result = await service.upload_skill_from_zip(NAMESPACE, zip_bytes)
+        print(f"    result: {result}")
+    else:
+        print(f"    SKIP: {ZIP_PATH} not found")
+
+    print("\n  Skill API Tests: ALL PASSED")
+
+
+async def main():
+    config = (
+        ClientConfigBuilder()
+        .server_address(SERVER)
+        .username(USERNAME)
+        .password(PASSWORD)
+        .build()
+    )
+    service = await NacosAIMaintainerService.create_ai_service(config)
+
+    try:
+        await test_prompt(service)
+    except Exception as e:
+        print(f"\n  Prompt test FAILED: {e}")
+        traceback.print_exc()
+
+    try:
+        await test_skill(service)
+    except Exception as e:
+        print(f"\n  Skill test FAILED: {e}")
+        traceback.print_exc()
+
+    print("\n" + "=" * 60)
+    print("  All tests completed!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Add Prompt management (9 APIs): publish, delete, list, search, get metadata, update metadata, query detail, list versions, bind/unbind label.

Add Skill management (7 APIs): register, get detail, update, delete, list, search, upload from zip.

New model classes: PromptMetaSummary, PromptMetaInfo, PromptVersionSummary, PromptVersionInfo, Skill, SkillBasicInfo, SkillResource.

Support multipart file upload for skill zip upload. Update example with prompt and skill usage demos.
Add integration test script (test_prompt_skill.py). Bump version to 0.6.0b1.

Made-with: Cursor